### PR TITLE
Layout options supports expression.

### DIFF
--- a/src/lib/src/widget-library/button.component.ts
+++ b/src/lib/src/widget-library/button.component.ts
@@ -27,7 +27,6 @@ export class ButtonComponent implements OnInit {
   formControl: AbstractControl;
   controlName: string;
   controlValue: any;
-  controlDisabled = false;
   boundControl = false;
   options: any;
   @Input() layoutNode: any;
@@ -41,6 +40,10 @@ export class ButtonComponent implements OnInit {
   ngOnInit() {
     this.options = this.layoutNode.options || {};
     this.jsf.initializeControl(this);
+  }
+
+  get controlDisabled(): boolean {
+    return this.jsf.evaluateDisabled(this.layoutNode, this.dataIndex);
   }
 
   updateValue(event) {

--- a/src/lib/src/widget-library/checkbox.component.ts
+++ b/src/lib/src/widget-library/checkbox.component.ts
@@ -12,6 +12,7 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
       <input *ngIf="boundControl"
         [formControl]="formControl"
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+        [attr.disabled]="controlDisabled ? '' : null"
         [class]="(options?.fieldHtmlClass || '') + (isChecked ?
           (' ' + (options?.activeClass || '') + ' ' + (options?.style?.selected || '')) :
           (' ' + (options?.style?.unselected || '')))"
@@ -41,7 +42,6 @@ export class CheckboxComponent implements OnInit {
   formControl: AbstractControl;
   controlName: string;
   controlValue: any;
-  controlDisabled = false;
   boundControl = false;
   options: any;
   trueValue: any = true;
@@ -60,6 +60,10 @@ export class CheckboxComponent implements OnInit {
     if (this.controlValue === null || this.controlValue === undefined) {
       this.controlValue = this.options.title;
     }
+  }
+
+  get controlDisabled(): boolean {
+    return this.jsf.evaluateDisabled(this.layoutNode, this.dataIndex);
   }
 
   updateValue(event) {

--- a/src/lib/src/widget-library/checkboxes.component.ts
+++ b/src/lib/src/widget-library/checkboxes.component.ts
@@ -60,7 +60,6 @@ export class CheckboxesComponent implements OnInit {
   formControl: AbstractControl;
   controlName: string;
   controlValue: any;
-  controlDisabled = false;
   boundControl = false;
   options: any;
   layoutOrientation: string;
@@ -88,6 +87,10 @@ export class CheckboxesComponent implements OnInit {
         checkboxItem.checked = formArray.value.includes(checkboxItem.value)
       );
     }
+  }
+
+  get controlDisabled(): boolean {
+    return this.jsf.evaluateDisabled(this.layoutNode, this.dataIndex);
   }
 
   updateValue(event) {

--- a/src/lib/src/widget-library/file.component.ts
+++ b/src/lib/src/widget-library/file.component.ts
@@ -13,7 +13,6 @@ export class FileComponent implements OnInit {
   formControl: AbstractControl;
   controlName: string;
   controlValue: any;
-  controlDisabled = false;
   boundControl = false;
   options: any;
   @Input() layoutNode: any;
@@ -27,6 +26,10 @@ export class FileComponent implements OnInit {
   ngOnInit() {
     this.options = this.layoutNode.options || {};
     this.jsf.initializeControl(this);
+  }
+
+  get controlDisabled(): boolean {
+    return this.jsf.evaluateDisabled(this.layoutNode, this.dataIndex);
   }
 
   updateValue(event) {

--- a/src/lib/src/widget-library/hidden.component.ts
+++ b/src/lib/src/widget-library/hidden.component.ts
@@ -8,6 +8,7 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
   template: `
     <input *ngIf="boundControl"
       [formControl]="formControl"
+      [attr.disabled]="controlDisabled ? '' : null"
       [id]="'control' + layoutNode?._id"
       [name]="controlName"
       type="hidden">
@@ -22,7 +23,6 @@ export class HiddenComponent implements OnInit {
   formControl: AbstractControl;
   controlName: string;
   controlValue: any;
-  controlDisabled = false;
   boundControl = false;
   @Input() layoutNode: any;
   @Input() layoutIndex: number[];
@@ -34,5 +34,9 @@ export class HiddenComponent implements OnInit {
 
   ngOnInit() {
     this.jsf.initializeControl(this);
+  }
+
+  get controlDisabled(): boolean {
+    return this.jsf.evaluateDisabled(this.layoutNode, this.dataIndex);
   }
 }

--- a/src/lib/src/widget-library/input.component.ts
+++ b/src/lib/src/widget-library/input.component.ts
@@ -21,6 +21,7 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
         [attr.pattern]="options?.pattern"
         [attr.placeholder]="options?.placeholder"
         [attr.required]="options?.required"
+        [attr.disabled]="controlDisabled ? '' : null"
         [class]="options?.fieldHtmlClass || ''"
         [id]="'control' + layoutNode?._id"
         [name]="controlName"
@@ -52,7 +53,6 @@ export class InputComponent implements OnInit {
   formControl: AbstractControl;
   controlName: string;
   controlValue: string;
-  controlDisabled = false;
   boundControl = false;
   options: any;
   autoCompleteList: string[] = [];
@@ -67,6 +67,10 @@ export class InputComponent implements OnInit {
   ngOnInit() {
     this.options = this.layoutNode.options || {};
     this.jsf.initializeControl(this);
+  }
+
+  get controlDisabled(): boolean {
+    return this.jsf.evaluateDisabled(this.layoutNode, this.dataIndex);
   }
 
   updateValue(event) {

--- a/src/lib/src/widget-library/number.component.ts
+++ b/src/lib/src/widget-library/number.component.ts
@@ -18,6 +18,7 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
         [attr.max]="options?.maximum"
         [attr.min]="options?.minimum"
         [attr.placeholder]="options?.placeholder"
+        [attr.disabled]="controlDisabled ? '' : null"
         [attr.required]="options?.required"
         [attr.readonly]="options?.readonly ? 'readonly' : null"
         [attr.step]="options?.multipleOf || options?.step || 'any'"
@@ -51,7 +52,6 @@ export class NumberComponent implements OnInit {
   formControl: AbstractControl;
   controlName: string;
   controlValue: any;
-  controlDisabled = false;
   boundControl = false;
   options: any;
   allowNegative = true;
@@ -70,6 +70,10 @@ export class NumberComponent implements OnInit {
     this.options = this.layoutNode.options || {};
     this.jsf.initializeControl(this);
     if (this.layoutNode.dataType === 'integer') { this.allowDecimal = false; }
+  }
+
+  get controlDisabled(): boolean {
+    return this.jsf.evaluateDisabled(this.layoutNode, this.dataIndex);
   }
 
   updateValue(event) {

--- a/src/lib/src/widget-library/radios.component.ts
+++ b/src/lib/src/widget-library/radios.component.ts
@@ -67,7 +67,6 @@ export class RadiosComponent implements OnInit {
   formControl: AbstractControl;
   controlName: string;
   controlValue: any;
-  controlDisabled = false;
   boundControl = false;
   options: any;
   layoutOrientation = 'vertical';
@@ -92,6 +91,10 @@ export class RadiosComponent implements OnInit {
       this.options.enum, true
     );
     this.jsf.initializeControl(this);
+  }
+
+  get controlDisabled(): boolean {
+    return this.jsf.evaluateDisabled(this.layoutNode, this.dataIndex);
   }
 
   updateValue(event) {

--- a/src/lib/src/widget-library/select.component.ts
+++ b/src/lib/src/widget-library/select.component.ts
@@ -19,6 +19,7 @@ import { buildTitleMap, isArray } from '../shared';
         [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
         [attr.readonly]="options?.readonly ? 'readonly' : null"
         [attr.required]="options?.required"
+        [attr.disabled]="controlDisabled ? '' : null"
         [class]="options?.fieldHtmlClass || ''"
         [id]="'control' + layoutNode?._id"
         [name]="controlName">
@@ -67,7 +68,6 @@ export class SelectComponent implements OnInit {
   formControl: AbstractControl;
   controlName: string;
   controlValue: any;
-  controlDisabled = false;
   boundControl = false;
   options: any;
   selectList: any[] = [];
@@ -87,6 +87,10 @@ export class SelectComponent implements OnInit {
       this.options.enum, !!this.options.required, !!this.options.flatList
     );
     this.jsf.initializeControl(this);
+  }
+
+  get controlDisabled(): boolean {
+    return this.jsf.evaluateDisabled(this.layoutNode, this.dataIndex);
   }
 
   updateValue(event) {

--- a/src/lib/src/widget-library/submit.component.ts
+++ b/src/lib/src/widget-library/submit.component.ts
@@ -20,13 +20,14 @@ import { hasOwn } from '../shared/utility.functions';
         [type]="layoutNode?.type"
         [value]="controlValue"
         (click)="updateValue($event)">
+        {{controlDisabled}}
     </div>`,
 })
 export class SubmitComponent implements OnInit {
   formControl: AbstractControl;
   controlName: string;
   controlValue: any;
-  controlDisabled = false;
+  _controlDisabled = false;
   boundControl = false;
   options: any;
   @Input() layoutNode: any;
@@ -41,14 +42,18 @@ export class SubmitComponent implements OnInit {
     this.options = this.layoutNode.options || {};
     this.jsf.initializeControl(this);
     if (hasOwn(this.options, 'disabled')) {
-      this.controlDisabled = this.options.disabled;
+      this._controlDisabled = this.jsf.evaluateDisabled(this.layoutNode, this.dataIndex);
     } else if (this.jsf.formOptions.disableInvalidSubmit) {
-      this.controlDisabled = !this.jsf.isValid;
-      this.jsf.isValidChanges.subscribe(isValid => this.controlDisabled = !isValid);
+      this._controlDisabled = !this.jsf.isValid;
+      this.jsf.isValidChanges.subscribe(isValid => this._controlDisabled = !isValid);
     }
     if (this.controlValue === null || this.controlValue === undefined) {
       this.controlValue = this.options.title;
     }
+  }
+
+  get controlDisabled(): boolean {
+    return this._controlDisabled || this.jsf.evaluateDisabled(this.layoutNode, this.dataIndex);
   }
 
   updateValue(event) {

--- a/src/lib/src/widget-library/textarea.component.ts
+++ b/src/lib/src/widget-library/textarea.component.ts
@@ -22,6 +22,7 @@ import { JsonSchemaFormService } from '../json-schema-form.service';
         [attr.placeholder]="options?.placeholder"
         [attr.readonly]="options?.readonly ? 'readonly' : null"
         [attr.required]="options?.required"
+        [attr.disabled]="controlDisabled ? '' : null"
         [class]="options?.fieldHtmlClass || ''"
         [id]="'control' + layoutNode?._id"
         [name]="controlName"></textarea>
@@ -45,7 +46,6 @@ export class TextareaComponent implements OnInit {
   formControl: AbstractControl;
   controlName: string;
   controlValue: any;
-  controlDisabled = false;
   boundControl = false;
   options: any;
   @Input() layoutNode: any;
@@ -59,6 +59,10 @@ export class TextareaComponent implements OnInit {
   ngOnInit() {
     this.options = this.layoutNode.options || {};
     this.jsf.initializeControl(this);
+  }
+
+  get controlDisabled(): boolean {
+    return this.jsf.evaluateDisabled(this.layoutNode, this.dataIndex);
   }
 
   updateValue(event) {


### PR DESCRIPTION
## PR Type
What changes does this PR include (check all that apply)?
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build process changes
[ ] Documentation changes
[ ] Other... please describe:

## Related issue / current behavior
<!-- Please link to the issue you are resolving, or describe the current behavior that you are modifying. -->
Currently condition `option` in layout node supports expression and show/hide the elements. We need to provide expression support for other options like disabled as well.

## New behavior
<!-- Describe the new behavior, and how it fixes the original issue. -->

Now we can use expression for disabled option as well. eg
```
const layout = [
	{
		"key": "editable",
		"type": "checkbox"
	},
	{
		"key": "name",
		"type": "text",
		"disabled": "editable" // conditionally enables and disables the control.
	}
];
```
## Does this PR introduce a breaking change?
[ ] Yes
[x] No
